### PR TITLE
feat: add climate control

### DIFF
--- a/custom_components/aito/__init__.py
+++ b/custom_components/aito/__init__.py
@@ -230,8 +230,13 @@ def _remove_legacy_entities(
         for vehicle_id, spec in vehicle_specs.items()
         if spec.supports_sentry_mode
     )
+    climate_unique_ids = {
+        f"{vehicle_id}_air_conditioner"
+        for vehicle_id, spec in vehicle_specs.items()
+        if spec.supports_air_conditioner
+    }
     for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if entity.unique_id not in raw_status_unique_ids | mapped_unique_ids | switch_unique_ids:
+        if entity.unique_id not in raw_status_unique_ids | mapped_unique_ids | switch_unique_ids | climate_unique_ids:
             registry.async_remove(entity.entity_id)
 
 

--- a/custom_components/aito/api.py
+++ b/custom_components/aito/api.py
@@ -264,6 +264,8 @@ class AitoApiClient:
         target_temp: int | None = None,
     ) -> None:
         """Run the observed A/C command and wait for its asynchronous result."""
+        if enabled and target_temp is None:
+            raise ValueError("AITO air-conditioner requires targetTemp when enabling")
         query = {"enabled": str(enabled).lower()}
         if target_temp is not None:
             query["targetTemp"] = str(target_temp)

--- a/custom_components/aito/climate.py
+++ b/custom_components/aito/climate.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from math import isclose
+from typing import Any
+
+from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import AitoDataCoordinator
+from .models import Vehicle, vehicle_device_info
+
+_PRESET_RAPID_COOL = "rapid_cool"
+_PRESET_RAPID_HEAT = "rapid_heat"
+_PRESET_DEFROST = "defrost"
+_PRESETS = (_PRESET_RAPID_COOL, _PRESET_RAPID_HEAT, _PRESET_DEFROST)
+
+
+async def async_setup_entry(hass, entry, async_add_entities) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data.get("coordinator")
+    if coordinator is None:
+        return
+    entities = [
+        AitoAirConditioner(coordinator, vehicle)
+        for vehicle in data["vehicles"]
+        if (spec := data["vehicle_specs"].get(vehicle.id)) and spec.supports_air_conditioner
+    ]
+    async_add_entities(entities)
+
+
+class AitoAirConditioner(CoordinatorEntity[AitoDataCoordinator], ClimateEntity):
+    """Represent the vehicle's remotely controlled air conditioner."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "air_conditioner"
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
+    _attr_preset_modes = list(_PRESETS)
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_min_temp = 16
+    _attr_max_temp = 31
+    _attr_target_temperature_step = 0.5
+
+    def __init__(self, coordinator: AitoDataCoordinator, vehicle: Vehicle) -> None:
+        super().__init__(coordinator)
+        self._vehicle_id = vehicle.id
+        self._attr_unique_id = f"{vehicle.id}_air_conditioner"
+        self._attr_device_info = vehicle_device_info(vehicle)
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._hvac is not None
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        status = self._value("acStatus")
+        if status is None:
+            return None
+        return HVACMode.AUTO if status in {1, "1"} else HVACMode.OFF
+
+    @property
+    def target_temperature(self) -> float | None:
+        return _target_temperature_celsius(self._value("remoteTemp"))
+
+    @property
+    def current_temperature(self) -> float | None:
+        return _temperature_celsius(self._value("insideTemp"))
+
+    @property
+    def preset_mode(self) -> str | None:
+        return self._active_preset
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.OFF:
+            await self.async_turn_off()
+            return
+        if hvac_mode == HVACMode.AUTO:
+            await self.async_turn_on()
+            return
+        raise ValueError(f"unsupported AITO HVAC mode: {hvac_mode}")
+
+    async def async_turn_on(self) -> None:
+        target_temp = _target_temperature_tenths(self.target_temperature)
+        await self.coordinator.async_control_air_conditioner(
+            self._vehicle_id,
+            enabled=True,
+            target_temp=target_temp,
+        )
+
+    async def async_turn_off(self) -> None:
+        await self.coordinator.async_control_air_conditioner(self._vehicle_id, enabled=False)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        target_temp = _target_temperature_tenths(kwargs.get(ATTR_TEMPERATURE))
+        await self.coordinator.async_control_air_conditioner(
+            self._vehicle_id,
+            enabled=True,
+            target_temp=target_temp,
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        if preset_mode not in _PRESETS:
+            raise ValueError(f"unsupported AITO air-conditioner preset: {preset_mode}")
+        active = self._active_preset
+        if active == preset_mode:
+            return
+        if active is not None:
+            await self._async_set_preset(active, enabled=False)
+        await self._async_set_preset(preset_mode, enabled=True)
+
+    async def _async_set_preset(self, preset: str, *, enabled: bool) -> None:
+        if preset == _PRESET_RAPID_COOL:
+            await self.coordinator.async_control_air_conditioner_rapid(
+                self._vehicle_id,
+                enabled=enabled,
+                mode=1,
+            )
+            return
+        if preset == _PRESET_RAPID_HEAT:
+            await self.coordinator.async_control_air_conditioner_rapid(
+                self._vehicle_id,
+                enabled=enabled,
+                mode=2,
+            )
+            return
+        if preset == _PRESET_DEFROST:
+            await self.coordinator.async_control_defrost(self._vehicle_id, enabled=enabled)
+
+    @property
+    def _active_preset(self) -> str | None:
+        active = [
+            preset
+            for preset, field in (
+                (_PRESET_RAPID_COOL, "maxColdSwitch"),
+                (_PRESET_RAPID_HEAT, "maxHeatSwitch"),
+                (_PRESET_DEFROST, "defrostStatus"),
+            )
+            if self._value(field) in {1, "1"}
+        ]
+        return active[0] if len(active) == 1 else None
+
+    @property
+    def _hvac(self) -> dict[str, Any] | None:
+        data = self.coordinator.data.get(self._vehicle_id, {}) if self.coordinator.data else {}
+        hvac = data.get("hvac")
+        return hvac if isinstance(hvac, dict) else None
+
+    def _value(self, field: str) -> Any:
+        hvac = self._hvac
+        return hvac.get(field) if hvac is not None else None
+
+
+def _temperature_celsius(value: Any) -> float | None:
+    return value / 10 if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _target_temperature_celsius(value: Any) -> float | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    if not 160 <= value <= 310 or value % 5:
+        return None
+    return value / 10
+
+
+def _target_temperature_tenths(value: Any) -> int:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError("AITO air-conditioner temperature is required")
+    if not 16 <= value <= 31 or not isclose(value * 2, round(value * 2)):
+        raise ValueError("AITO air-conditioner temperature must be 16.0-31.0 C in 0.5 C steps")
+    return round(value * 10)

--- a/custom_components/aito/const.py
+++ b/custom_components/aito/const.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 DOMAIN = "aito"
-PLATFORMS: tuple[str, ...] = ("sensor", "switch")
+PLATFORMS: tuple[str, ...] = ("sensor", "switch", "climate")
 
 CONF_PHONE = "phone"
 CONF_PASSWORD = "password"

--- a/custom_components/aito/coordinator.py
+++ b/custom_components/aito/coordinator.py
@@ -116,6 +116,47 @@ class AitoDataCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         )
         await self.async_request_refresh()
 
+    async def async_control_air_conditioner(
+        self,
+        vehicle_id: str,
+        *,
+        enabled: bool,
+        target_temp: int | None = None,
+    ) -> None:
+        await self._async_control_command(
+            partial(
+                self.client.control_air_conditioner,
+                vehicle_id,
+                enabled=enabled,
+                target_temp=target_temp,
+            )
+        )
+
+    async def async_control_air_conditioner_rapid(
+        self,
+        vehicle_id: str,
+        *,
+        enabled: bool,
+        mode: int,
+    ) -> None:
+        await self._async_control_command(
+            partial(
+                self.client.control_air_conditioner_rapid,
+                vehicle_id,
+                enabled=enabled,
+                mode=mode,
+            )
+        )
+
+    async def async_control_defrost(self, vehicle_id: str, *, enabled: bool) -> None:
+        await self._async_control_command(
+            partial(self.client.control_defrost, vehicle_id, enabled=enabled)
+        )
+
+    async def _async_control_command(self, request) -> None:
+        await self._async_apig_request(request, retry_after_refresh=False)
+        await self.async_request_refresh()
+
     async def _async_latest_energy_report(self, vehicle_id: str) -> dict[str, Any] | None:
         now = time.monotonic()
         if now < self._energy_report_refresh_at.get(vehicle_id, 0):

--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -27,6 +27,7 @@ class VehicleSpec:
     sensors: tuple[SensorSpec, ...]
     supports_now_departure_plan: bool = False
     supports_sentry_mode: bool = False
+    supports_air_conditioner: bool = False
 
     def matches(self, vehicle: Vehicle) -> bool:
         profile = vehicle.profile
@@ -55,6 +56,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
         project_code="SERES-F3",
         supports_now_departure_plan=True,
         supports_sentry_mode=True,
+        supports_air_conditioner=True,
         sensors=(
             SensorSpec(
                 key="battery_soc",
@@ -161,6 +163,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
         enterprise_code="SERES",
         project_code="SERES-X1",
         supports_sentry_mode=True,
+        supports_air_conditioner=True,
         sensors=(
             SensorSpec(
                 key="battery_soc",
@@ -275,6 +278,8 @@ def dynamic_sections(spec: VehicleSpec) -> dict[str, int]:
         sections["departurePlan"] = 0
     if spec.supports_sentry_mode:
         sections["vehicleStatus"] = 0
+    if spec.supports_air_conditioner:
+        sections["hvac"] = 0
     return sections
 
 

--- a/custom_components/aito/strings.json
+++ b/custom_components/aito/strings.json
@@ -85,6 +85,20 @@
       "sentry_mode": {
         "name": "Sentry mode"
       }
+    },
+    "climate": {
+      "air_conditioner": {
+        "name": "Air conditioner",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "rapid_cool": "Rapid cool",
+              "rapid_heat": "Rapid heat",
+              "defrost": "Defrost"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/aito/translations/zh-Hans.json
+++ b/custom_components/aito/translations/zh-Hans.json
@@ -85,6 +85,20 @@
       "sentry_mode": {
         "name": "哨兵模式"
       }
+    },
+    "climate": {
+      "air_conditioner": {
+        "name": "空调",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "rapid_cool": "速冷",
+              "rapid_heat": "速热",
+              "defrost": "除霜"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a Home Assistant climate entity for supported AITO vehicles
- expose target temperature, rapid cooling/heating, and defrost controls
- add climate translations and capability gating

## Validation
- `python -m pytest -p no:cacheprovider tests` (26 passed)
- `python -m py_compile custom_components/aito/climate.py`