### PR TITLE
feat: 扩展车辆传感器（座舱温度/胎压/续航等）+ -1 无数据保值

### DIFF
--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from .models import Vehicle
@@ -17,6 +18,10 @@ class SensorSpec:
     state_class: str | None = None
     converter: Callable[[Any], Any] | None = None
     value_getter: Callable[[dict[str, Any]], Any] | None = None
+    # Keep the previous reading when the converter yields None (e.g. the -1
+    # no-data placeholder while the vehicle sleeps) instead of dropping to
+    # unknown. Used by tire pressure, SOC, range, temperatures, etc.
+    sticky: bool = False
 
 
 @dataclass(frozen=True)
@@ -37,7 +42,21 @@ class VehicleSpec:
 
 
 def _absolute_number(value: Any) -> float | int | None:
-    return abs(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value != -1:
+        return abs(value)
+    return None
+
+
+def _reject_sentinel(value: Any) -> Any:
+    """Treat the APIG -1 no-data placeholder as missing.
+
+    Combined with a sticky sensor this makes the entity hold its last real
+    reading instead of dropping to unknown. -1 is safe to special-case: the
+    tenth-degree temperatures encode a real -1C as -10, never -1.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value == -1:
+        return None
+    return value
 
 
 def _charge_power_kw(data: dict[str, Any]) -> float | None:
@@ -46,6 +65,50 @@ def _charge_power_kw(data: dict[str, Any]) -> float | None:
     if current is None or voltage is None:
         return None
     return round(int(round(current)) * int(round(voltage)) / 1000, 1)
+
+
+def _positive_number(value: Any) -> float | int | None:
+    """Drop the -1 placeholder the APIG reports while the vehicle sleeps."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def _tenths(value: Any) -> float | None:
+    """Convert the APIG tenth-degree temperatures (297) into Celsius (29.7)."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value != -1:
+        return round(value / 10, 1)
+    return None
+
+
+_CHARGE_STATUS_TEXT = {0: "未充电", 1: "充电中", 2: "充电完成", 3: "充电故障", 4: "充电暂停"}
+
+
+def _charge_status_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        status = int(value)
+    except (TypeError, ValueError):
+        return None
+    return _CHARGE_STATUS_TEXT.get(status, f"未知({status})")
+
+
+def _epoch_millis(value: Any) -> datetime | None:
+    """Convert the APIG millisecond timestamps into an aware datetime."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+    return None
+
+
+def _parking_text(value: Any) -> str | None:
+    """Report the electric park brake as the parked or driving state."""
+    if value is None:
+        return None
+    try:
+        return "停泊" if int(value) == 2 else "行驶"
+    except (TypeError, ValueError):
+        return None
 
 
 DEVICES: tuple[VehicleSpec, ...] = (
@@ -63,6 +126,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="battery",
                 native_unit_of_measurement="%",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_voltage",
@@ -72,6 +137,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="V",
                 state_class="measurement",
                 converter=_absolute_number,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_current",
@@ -81,6 +147,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="A",
                 state_class="measurement",
                 converter=_absolute_number,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_power",
@@ -90,6 +157,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="kW",
                 state_class="measurement",
                 value_getter=_charge_power_kw,
+                sticky=True,
             ),
             SensorSpec(
                 key="remaining_charge_time",
@@ -98,6 +166,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="duration",
                 native_unit_of_measurement="min",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="electric_wltc_remaining_mileage",
@@ -106,6 +176,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="wltc_remaining_mileage",
@@ -114,6 +186,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="total_mileage",
@@ -122,6 +196,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="total_increasing",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="fuel_wltc_remaining_mileage",
@@ -130,6 +206,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="fuel_remaining",
@@ -137,6 +215,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 translation_key="fuel_remaining",
                 native_unit_of_measurement="%",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="average_power_consumption",
@@ -154,6 +234,102 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="L/100km",
                 state_class="measurement",
             ),
+            SensorSpec(
+                key="sum_remaining_mileage",
+                path=("vehicleStatus", "sumRemainingMileage"),
+                translation_key="sum_remaining_mileage",
+                device_class="distance",
+                native_unit_of_measurement="km",
+                state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="last_updated_at",
+                path=("vehicleStatus", "lastUpdatedAt"),
+                translation_key="last_updated_at",
+                device_class="timestamp",
+                converter=_epoch_millis,
+            ),
+            SensorSpec(
+                key="last_online_at",
+                path=("vehicleStatus", "lastOnlineAt"),
+                translation_key="last_online_at",
+                device_class="timestamp",
+                converter=_epoch_millis,
+            ),
+            SensorSpec(
+                key="charge_status",
+                path=("charge", "chargeStatus"),
+                translation_key="charge_status",
+                converter=_charge_status_text,
+            ),
+            SensorSpec(
+                key="parking_status",
+                path=("vehicleStatus", "epbSts"),
+                translation_key="parking_status",
+                converter=_parking_text,
+            ),
+            SensorSpec(
+                key="inside_temperature",
+                path=("hvac", "insideTemp"),
+                translation_key="inside_temperature",
+                device_class="temperature",
+                native_unit_of_measurement="°C",
+                state_class="measurement",
+                converter=_tenths,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="air_conditioner_target_temperature",
+                path=("hvac", "remoteTemp"),
+                translation_key="air_conditioner_target_temperature",
+                device_class="temperature",
+                native_unit_of_measurement="°C",
+                state_class="measurement",
+                converter=_tenths,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="tire_pressure_left_front",
+                path=("tire", "leftFront", "pressure"),
+                translation_key="tire_pressure_left_front",
+                device_class="pressure",
+                native_unit_of_measurement="bar",
+                state_class="measurement",
+                converter=_positive_number,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="tire_pressure_right_front",
+                path=("tire", "rightFront", "pressure"),
+                translation_key="tire_pressure_right_front",
+                device_class="pressure",
+                native_unit_of_measurement="bar",
+                state_class="measurement",
+                converter=_positive_number,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="tire_pressure_left_back",
+                path=("tire", "leftBack", "pressure"),
+                translation_key="tire_pressure_left_back",
+                device_class="pressure",
+                native_unit_of_measurement="bar",
+                state_class="measurement",
+                converter=_positive_number,
+                sticky=True,
+            ),
+            SensorSpec(
+                key="tire_pressure_right_back",
+                path=("tire", "rightBack", "pressure"),
+                translation_key="tire_pressure_right_back",
+                device_class="pressure",
+                native_unit_of_measurement="bar",
+                state_class="measurement",
+                converter=_positive_number,
+                sticky=True,
+            ),
         ),
     ),
     VehicleSpec(
@@ -169,6 +345,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="battery",
                 native_unit_of_measurement="%",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_voltage",
@@ -178,6 +356,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="V",
                 state_class="measurement",
                 converter=_absolute_number,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_current",
@@ -187,6 +366,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="A",
                 state_class="measurement",
                 converter=_absolute_number,
+                sticky=True,
             ),
             SensorSpec(
                 key="charge_power",
@@ -196,6 +376,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 native_unit_of_measurement="kW",
                 state_class="measurement",
                 value_getter=_charge_power_kw,
+                sticky=True,
             ),
             SensorSpec(
                 key="remaining_charge_time",
@@ -204,6 +385,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="duration",
                 native_unit_of_measurement="min",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="electric_wltc_remaining_mileage",
@@ -212,6 +395,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="wltc_remaining_mileage",
@@ -220,6 +405,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="total_mileage",
@@ -228,6 +415,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="total_increasing",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="fuel_wltc_remaining_mileage",
@@ -236,6 +425,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 device_class="distance",
                 native_unit_of_measurement="km",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="fuel_remaining",
@@ -243,6 +434,8 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 translation_key="fuel_remaining",
                 native_unit_of_measurement="%",
                 state_class="measurement",
+                converter=_reject_sentinel,
+                sticky=True,
             ),
             SensorSpec(
                 key="average_power_consumption",

--- a/custom_components/aito/sensor.py
+++ b/custom_components/aito/sensor.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -20,6 +25,12 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         AitoRawVehicleStatusSensor(vehicle, snapshots.get(vehicle.id))
         for vehicle in data["vehicles"]
     ]
+    for index, vehicle in enumerate(data["vehicles"]):
+        # Fix the first vehicle's model sensor id so the Lovelace card can
+        # reference it directly for its title.
+        entities.append(
+            AitoVehicleModelSensor(vehicle, "sensor.aito_model" if index == 0 else None)
+        )
     coordinator = data.get("coordinator")
     if coordinator is not None:
         for vehicle in data["vehicles"]:
@@ -27,6 +38,21 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             if spec is not None:
                 entities.extend(AitoMappedSensor(coordinator, vehicle, sensor) for sensor in spec.sensors)
     async_add_entities(entities)
+
+
+class AitoVehicleModelSensor(SensorEntity):
+    """The vehicle's model name, reported once from the login vehicle list."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "model"
+
+    def __init__(self, vehicle: Vehicle, fixed_entity_id: str | None = None) -> None:
+        self._attr_unique_id = f"{vehicle.id}_model"
+        self._attr_device_info = vehicle_device_info(vehicle)
+        self._attr_native_value = vehicle.model or vehicle.name
+        if fixed_entity_id:
+            self.entity_id = fixed_entity_id
 
 
 class AitoRawVehicleStatusSensor(RestoreEntity, SensorEntity):
@@ -61,7 +87,7 @@ class AitoRawVehicleStatusSensor(RestoreEntity, SensorEntity):
         self._attr_extra_state_attributes = snapshot
 
 
-class AitoMappedSensor(CoordinatorEntity[AitoDataCoordinator], SensorEntity):
+class AitoMappedSensor(CoordinatorEntity[AitoDataCoordinator], RestoreSensor):
     """A sensor explicitly declared for a matching vehicle project."""
 
     _attr_has_entity_name = True
@@ -73,6 +99,7 @@ class AitoMappedSensor(CoordinatorEntity[AitoDataCoordinator], SensorEntity):
         self._attr_unique_id = f"{vehicle.id}_{spec.key}"
         self._attr_device_info = vehicle_device_info(vehicle)
         self._attr_translation_key = spec.translation_key
+        self._last_value: Any = None
         if spec.device_class:
             self._attr_device_class = SensorDeviceClass(spec.device_class)
         if spec.native_unit_of_measurement:
@@ -80,7 +107,22 @@ class AitoMappedSensor(CoordinatorEntity[AitoDataCoordinator], SensorEntity):
         if spec.state_class:
             self._attr_state_class = SensorStateClass(spec.state_class)
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if not self._spec.sticky:
+            return
+        if (last := await self.async_get_last_sensor_data()) is not None and last.native_value is not None:
+            self._last_value = last.native_value
+
     @property
     def native_value(self):
         data = self.coordinator.data.get(self._vehicle_id, {}) if self.coordinator.data else {}
-        return sensor_value(data, self._spec)
+        value = sensor_value(data, self._spec)
+        if value is not None:
+            self._last_value = value
+            return value
+        # A sticky sensor keeps its previous reading when the vehicle stops
+        # reporting (e.g. tire pressure while asleep) instead of going unknown.
+        if self._spec.sticky:
+            return self._last_value
+        return value

--- a/custom_components/aito/strings.json
+++ b/custom_components/aito/strings.json
@@ -76,6 +76,42 @@
       },
       "average_fuel_consumption": {
         "name": "Average fuel consumption"
+      },
+      "sum_remaining_mileage": {
+        "name": "Combined range"
+      },
+      "charge_status": {
+        "name": "Charging status"
+      },
+      "parking_status": {
+        "name": "Parking status"
+      },
+      "inside_temperature": {
+        "name": "Cabin temperature"
+      },
+      "air_conditioner_target_temperature": {
+        "name": "A/C target temperature"
+      },
+      "tire_pressure_left_front": {
+        "name": "Left front tire pressure"
+      },
+      "tire_pressure_right_front": {
+        "name": "Right front tire pressure"
+      },
+      "tire_pressure_left_back": {
+        "name": "Left rear tire pressure"
+      },
+      "tire_pressure_right_back": {
+        "name": "Right rear tire pressure"
+      },
+      "last_updated_at": {
+        "name": "Vehicle data timestamp"
+      },
+      "last_online_at": {
+        "name": "Vehicle last online"
+      },
+      "model": {
+        "name": "Model"
       }
     },
     "switch": {

--- a/custom_components/aito/translations/zh-Hans.json
+++ b/custom_components/aito/translations/zh-Hans.json
@@ -76,6 +76,42 @@
       },
       "average_fuel_consumption": {
         "name": "平均油耗"
+      },
+      "sum_remaining_mileage": {
+        "name": "综合剩余里程"
+      },
+      "charge_status": {
+        "name": "充电状态"
+      },
+      "parking_status": {
+        "name": "驻车状态"
+      },
+      "inside_temperature": {
+        "name": "车内温度"
+      },
+      "air_conditioner_target_temperature": {
+        "name": "空调设定温度"
+      },
+      "tire_pressure_left_front": {
+        "name": "左前胎压"
+      },
+      "tire_pressure_right_front": {
+        "name": "右前胎压"
+      },
+      "tire_pressure_left_back": {
+        "name": "左后胎压"
+      },
+      "tire_pressure_right_back": {
+        "name": "右后胎压"
+      },
+      "last_updated_at": {
+        "name": "车端数据时间"
+      },
+      "last_online_at": {
+        "name": "车辆最后在线"
+      },
+      "model": {
+        "name": "车型"
       }
     },
     "switch": {


### PR DESCRIPTION
## 概述
补全 `dynamic-infos` 接口已返回、但集成尚未映射为实体的车辆数据（SERES-F3 ）。

## 新增传感器
车内温度、空调设定温度、四轮胎压、综合剩余里程、充电状态、驻车（EPB）状态、车端数据时间、车辆最后在线时间、车型名。

## -1 无数据保值
数值传感器改为「粘滞」：当接口返回 `-1` 占位符（车辆休眠时）时，保留上一次有效读数（通过 `RestoreSensor` 跨重启恢复），而不是掉成 unknown。

`-1` 可以安全地特判：温度采用 ×10 编码，真实的 -1℃ 会是原始值 `-10` 而不是 `-1`，因此判断 `raw == -1` 不会误伤合法的负温。