### PR TITLE
fix: 控制指令 resultCode 302（状态未变）视为幂等成功

### DIFF
--- a/custom_components/aito/api.py
+++ b/custom_components/aito/api.py
@@ -60,6 +60,10 @@ class AitoApiError(RuntimeError):
 class AitoCommandError(RuntimeError):
     """A vehicle command was rejected or did not finish in time."""
 
+    def __init__(self, message: str, *, result_code: Any = None) -> None:
+        super().__init__(message)
+        self.result_code = result_code
+
 
 class AitoApiClient:
     def __init__(
@@ -387,7 +391,10 @@ class AitoApiClient:
             if result_code in {0, "0"}:
                 return
             if result_code not in {-100, "-100"}:
-                raise AitoCommandError(f"AITO vehicle command failed with resultCode={result_code!r}")
+                raise AitoCommandError(
+                    f"AITO vehicle command failed with resultCode={result_code!r}",
+                    result_code=result_code,
+                )
             if time.monotonic() >= deadline:
                 raise AitoCommandError("AITO vehicle command timed out")
             time.sleep(0.5)

--- a/custom_components/aito/coordinator.py
+++ b/custom_components/aito/coordinator.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
     class ConfigEntryAuthFailed(RuntimeError):
         pass
 
-from .api import AitoApiClient, AitoApiError
+from .api import AitoApiClient, AitoApiError, AitoCommandError
 from .auth import P256KeyPair, extract_credentials, extract_vehicle_authorization, session_key_status
 from .const import (
     CONF_ACCESS_TOKEN,
@@ -48,6 +48,9 @@ from .storage import decrypt_password, decrypt_session_context, encrypt_session_
 _LOGGER = logging.getLogger(__name__)
 
 _ENERGY_REPORT_REFRESH_SECONDS = 60 * 60
+
+# The vehicle answers a command that would not change its state with this code.
+_COMMAND_STATE_UNCHANGED_CODES = frozenset({302, "302"})
 
 
 class AitoDataCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -103,17 +106,35 @@ class AitoDataCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         return await self._async_apig_request(self.client.dynamic_infos, vehicle_id, sections)
 
     async def async_control_now_departure_plan(self, vehicle_id: str, *, enabled: bool) -> None:
-        await self._async_apig_request(
+        await self._async_run_vehicle_command(
             partial(self.client.control_now_departure_plan, vehicle_id, enabled=enabled),
-            retry_after_refresh=False,
+            "now departure plan",
         )
-        await self.async_request_refresh()
 
     async def async_control_sentry_mode(self, vehicle_id: str, *, enabled: bool) -> None:
-        await self._async_apig_request(
+        await self._async_run_vehicle_command(
             partial(self.client.control_sentry_mode, vehicle_id, enabled=enabled),
-            retry_after_refresh=False,
+            "sentry mode",
         )
+
+    async def _async_run_vehicle_command(self, request, description: str) -> None:
+        """Run a vehicle command, treating "state unchanged" as success.
+
+        The vehicle rejects a command that would not change anything (turning off
+        sentry mode while it is already off) with resultCode 302. That is not a
+        failure worth raising at the user, so log it and let the refresh below
+        report whatever the vehicle actually thinks its state is.
+        """
+        try:
+            await self._async_apig_request(request, retry_after_refresh=False)
+        except AitoCommandError as error:
+            if error.result_code not in _COMMAND_STATE_UNCHANGED_CODES:
+                raise
+            _LOGGER.info(
+                "AITO %s command reported resultCode %r (state already applied); refreshing instead",
+                description,
+                error.result_code,
+            )
         await self.async_request_refresh()
 
     async def _async_latest_energy_report(self, vehicle_id: str) -> dict[str, Any] | None:


### PR DESCRIPTION
## 问题
车辆对「不会改变自身状态的指令」（例如对**已经关闭**的哨兵模式再次下发关闭）会返回 `resultCode 302`（`extraData` 为空、无文字说明），本质是「这条指令不改变任何状态，拒绝执行」。开启一个已开启的同理。

## 修复
将 `302` 视为幂等成功——记录一条 info 日志并刷新真实状态，而不是向用户抛错。其他错误码仍照常抛出。`AitoCommandError` 新增 `result_code` 字段。备车、哨兵两个开关都走这个逻辑。