### PR TITLE
feat: 车辆休眠时保留上次数据、过滤温度占位值

### DIFF
--- a/custom_components/aito/coordinator.py
+++ b/custom_components/aito/coordinator.py
@@ -93,6 +93,16 @@ class AitoDataCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
                 continue
             raw = await self._async_dynamic_infos(vehicle.id, dynamic_sections(spec))
             data = raw if isinstance(raw, dict) else {}
+            # While the vehicle sleeps (connectStatus=0) it stops reporting live
+            # data and the API returns placeholder values (cabin temp 20.0C, A/C
+            # temp 6553.5C, etc. — plausible-looking but fake). Keep the previous
+            # frame so they don't overwrite real values. Do NOT substitute an
+            # empty frame when there is no previous data: that would make the
+            # departure-plan / sentry / A/C entities unavailable and block the
+            # controls, exactly when the user needs to send a wake/command.
+            previous = (self.data or {}).get(vehicle.id)
+            if _is_vehicle_offline(data) and isinstance(previous, dict) and previous:
+                data = previous
             if has_energy_report_sensors(spec):
                 report = await self._async_latest_energy_report(vehicle.id)
                 if report is not None:
@@ -524,6 +534,16 @@ def _session_huawei_cookies(context: dict[str, Any]) -> dict[str, str]:
         for name, value in cookies.items()
         if isinstance(name, str) and isinstance(value, str) and name and value
     }
+
+
+def _is_vehicle_offline(data: dict[str, Any]) -> bool:
+    """The vehicle is asleep/offline when vehicleStatus.connectStatus is 0.
+
+    While offline it stops reporting live data and the API returns placeholder
+    values, so callers should keep the last known data instead.
+    """
+    vehicle_status = data.get("vehicleStatus") if isinstance(data, dict) else None
+    return isinstance(vehicle_status, dict) and vehicle_status.get("connectStatus") == 0
 
 
 def _is_cancelled_apig_token(error: AitoApiError) -> bool:


### PR DESCRIPTION
## 问题
车辆休眠时（`vehicleStatus.connectStatus == 0`）不再上报实时数据，接口返回看似合法的**占位值**——实测车内温度 20.0℃（原始值 200）、空调设定温度 6553.5℃（原始值 65535 / 0xFFFF）。这些会被刷进实体、显示成真实值。

## 修改
`connectStatus == 0` 且有上次数据时，整帧沿用上次数据，而不是占位帧。**刻意不在"无上次数据"时给空帧**——否则备车/哨兵/空调控制实体会变 `unavailable`、控制被屏蔽，而休眠恰恰是最需要下发唤醒/指令的时候。

> 只用一个 `connectStatus` 总闸判断休眠、整帧保留，就覆盖了所有休眠占位（包括 65535）；不需要再在各字段里单独过滤特殊值。