### PR TITLE
refactor: 车型共享同一份传感器表（修复 M5 几乎无数据）

### DIFF
--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -113,16 +113,11 @@ def _parking_text(value: Any) -> str | None:
         return None
 
 
-DEVICES: tuple[VehicleSpec, ...] = (
-    VehicleSpec(
-        key="seres_f3",
-        enterprise_code="SERES",
-        project_code="SERES-F3",
-        supports_now_departure_plan=True,
-        supports_sentry_mode=True,
-        supports_air_conditioner=True,
-        supports_location=True,
-        sensors=(
+# 两个车型的传感器定义原本逐字重复。这些字段都来自同一套 dynamic-infos
+# section（charge / fuel / vehicleStatus / hvac / tire），与具体车型无关，
+# 所以抽成公共表；车型之间真正的差异只在下面的 supports_* 能力开关。
+# 某个车型不上报的字段会是 unknown（sticky 传感器则保留上次真值）。
+_COMMON_SENSORS: tuple[SensorSpec, ...] = (
             SensorSpec(
                 key="battery_soc",
                 path=("charge", "soc"),
@@ -334,7 +329,19 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 converter=_positive_number,
                 sticky=True,
             ),
-        ),
+)
+
+
+DEVICES: tuple[VehicleSpec, ...] = (
+    VehicleSpec(
+        key="seres_f3",
+        enterprise_code="SERES",
+        project_code="SERES-F3",
+        supports_now_departure_plan=True,
+        supports_sentry_mode=True,
+        supports_air_conditioner=True,
+        supports_location=True,
+        sensors=_COMMON_SENSORS,
     ),
     VehicleSpec(
         key="seres_x1",
@@ -343,123 +350,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
         supports_sentry_mode=True,
         supports_air_conditioner=True,
         supports_location=True,
-        sensors=(
-            SensorSpec(
-                key="battery_soc",
-                path=("charge", "soc"),
-                translation_key="battery_soc",
-                device_class="battery",
-                native_unit_of_measurement="%",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_voltage",
-                path=("charge", "chargeVoltage"),
-                translation_key="charge_voltage",
-                device_class="voltage",
-                native_unit_of_measurement="V",
-                state_class="measurement",
-                converter=_absolute_number,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_current",
-                path=("charge", "chargeCurrent"),
-                translation_key="charge_current",
-                device_class="current",
-                native_unit_of_measurement="A",
-                state_class="measurement",
-                converter=_absolute_number,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_power",
-                path=("charge",),
-                translation_key="charge_power",
-                device_class="power",
-                native_unit_of_measurement="kW",
-                state_class="measurement",
-                value_getter=_charge_power_kw,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="remaining_charge_time",
-                path=("charge", "remainChargeTime"),
-                translation_key="remaining_charge_time",
-                device_class="duration",
-                native_unit_of_measurement="min",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="electric_wltc_remaining_mileage",
-                path=("charge", "vcuWltcRemainingMileage"),
-                translation_key="electric_wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="wltc_remaining_mileage",
-                path=("vehicleStatus", "wltcRemainingMileage"),
-                translation_key="wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="total_mileage",
-                path=("vehicleStatus", "totalMileage"),
-                translation_key="total_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="total_increasing",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="fuel_wltc_remaining_mileage",
-                path=("fuel", "fuelWltcRemainingMileage"),
-                translation_key="fuel_wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="fuel_remaining",
-                path=("fuel", "leftPercent"),
-                translation_key="fuel_remaining",
-                native_unit_of_measurement="%",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="average_power_consumption",
-                path=("energyReport", "total", "avgPowerConsum"),
-                translation_key="average_power_consumption",
-                source="energy_report",
-                native_unit_of_measurement="kWh/100km",
-                state_class="measurement",
-            ),
-            SensorSpec(
-                key="average_fuel_consumption",
-                path=("energyReport", "total", "avgFuelConsum"),
-                translation_key="average_fuel_consumption",
-                source="energy_report",
-                native_unit_of_measurement="L/100km",
-                state_class="measurement",
-            ),
-        ),
+        sensors=_COMMON_SENSORS,
     ),
 )
 


### PR DESCRIPTION
## 问题
`SERES-X1`（问界 M5）的 spec 只声明了 12 个传感器，而这 12 个跟 `SERES-F3`（M8）的前 12 个**逐字相同**，另外 11 个完全缺失——车内温度、空调设定温度、四轮胎压、综合剩余里程、充电状态、驻车状态、两个时间戳。结果 M5 几乎看不到数据。

## 修改
抽一份 `_COMMON_SENSORS` 公共表，两个车型共同引用（净减 109 行重复）。以后新增传感器所有车型一起受益，不必在每个 spec 里重复。车型之间真正的差异保留在 `supports_*` 能力开关（例如 `SERES-X1` 无备车）。

## 关于"M5 是否真有这些字段"——请 review 时留意

我只有 M8 实车，**没有 M5 可验证**，所以分开说明依据强弱：

- **车内温度 / 空调设定温度**（`hvac.insideTemp` / `remoteTemp`）：`SERES-X1` 已声明 `supports_air_conditioner=True`，`dynamic_sections()` 因此本来就请求 `hvac`；且 M5 的 climate 实体本身就依赖这两个字段（`available` 依赖 `_hvac is not None`、`target_temperature` 读 `remoteTemp`）。依据较强。
- **综合续航 / 驻车 / 充电状态 / 两个时间戳**（`vehicleStatus`、`charge`）：这两个 section `SERES-X1` 本来就在请求，只是没做成实体。依据较强。
- **四轮胎压**（`tire`）：⚠️ `tire` 是本 PR 才为 `SERES-X1` 新增的 section，**我没有 M5 证据**。若 M5 不上报，这 4 个传感器会是 unknown（无害）；理论上更坏的情况是请求未支持的 section 导致整个响应异常——我在 M8 上一次请求全部 15 个 section 时服务端正常返回、只给有的数据，但 M5 上未验证。

如果你（或 M5 用户）确认 M5 不上报 `tire`，我可以把胎压改成按车型可选。