### PR TITLE
feat: 车型共享传感器表 + 未声明车型回退通用 spec

### DIFF
--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -113,16 +113,11 @@ def _parking_text(value: Any) -> str | None:
         return None
 
 
-DEVICES: tuple[VehicleSpec, ...] = (
-    VehicleSpec(
-        key="seres_f3",
-        enterprise_code="SERES",
-        project_code="SERES-F3",
-        supports_now_departure_plan=True,
-        supports_sentry_mode=True,
-        supports_air_conditioner=True,
-        supports_location=True,
-        sensors=(
+# 两个车型的传感器定义原本逐字重复。这些字段都来自同一套 dynamic-infos
+# section（charge / fuel / vehicleStatus / hvac / tire），与具体车型无关，
+# 所以抽成公共表；车型之间真正的差异只在下面的 supports_* 能力开关。
+# 某个车型不上报的字段会是 unknown（sticky 传感器则保留上次真值）。
+_COMMON_SENSORS: tuple[SensorSpec, ...] = (
             SensorSpec(
                 key="battery_soc",
                 path=("charge", "soc"),
@@ -334,7 +329,19 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 converter=_positive_number,
                 sticky=True,
             ),
-        ),
+)
+
+
+DEVICES: tuple[VehicleSpec, ...] = (
+    VehicleSpec(
+        key="seres_f3",
+        enterprise_code="SERES",
+        project_code="SERES-F3",
+        supports_now_departure_plan=True,
+        supports_sentry_mode=True,
+        supports_air_conditioner=True,
+        supports_location=True,
+        sensors=_COMMON_SENSORS,
     ),
     VehicleSpec(
         key="seres_x1",
@@ -343,123 +350,7 @@ DEVICES: tuple[VehicleSpec, ...] = (
         supports_sentry_mode=True,
         supports_air_conditioner=True,
         supports_location=True,
-        sensors=(
-            SensorSpec(
-                key="battery_soc",
-                path=("charge", "soc"),
-                translation_key="battery_soc",
-                device_class="battery",
-                native_unit_of_measurement="%",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_voltage",
-                path=("charge", "chargeVoltage"),
-                translation_key="charge_voltage",
-                device_class="voltage",
-                native_unit_of_measurement="V",
-                state_class="measurement",
-                converter=_absolute_number,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_current",
-                path=("charge", "chargeCurrent"),
-                translation_key="charge_current",
-                device_class="current",
-                native_unit_of_measurement="A",
-                state_class="measurement",
-                converter=_absolute_number,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="charge_power",
-                path=("charge",),
-                translation_key="charge_power",
-                device_class="power",
-                native_unit_of_measurement="kW",
-                state_class="measurement",
-                value_getter=_charge_power_kw,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="remaining_charge_time",
-                path=("charge", "remainChargeTime"),
-                translation_key="remaining_charge_time",
-                device_class="duration",
-                native_unit_of_measurement="min",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="electric_wltc_remaining_mileage",
-                path=("charge", "vcuWltcRemainingMileage"),
-                translation_key="electric_wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="wltc_remaining_mileage",
-                path=("vehicleStatus", "wltcRemainingMileage"),
-                translation_key="wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="total_mileage",
-                path=("vehicleStatus", "totalMileage"),
-                translation_key="total_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="total_increasing",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="fuel_wltc_remaining_mileage",
-                path=("fuel", "fuelWltcRemainingMileage"),
-                translation_key="fuel_wltc_remaining_mileage",
-                device_class="distance",
-                native_unit_of_measurement="km",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="fuel_remaining",
-                path=("fuel", "leftPercent"),
-                translation_key="fuel_remaining",
-                native_unit_of_measurement="%",
-                state_class="measurement",
-                converter=_reject_sentinel,
-                sticky=True,
-            ),
-            SensorSpec(
-                key="average_power_consumption",
-                path=("energyReport", "total", "avgPowerConsum"),
-                translation_key="average_power_consumption",
-                source="energy_report",
-                native_unit_of_measurement="kWh/100km",
-                state_class="measurement",
-            ),
-            SensorSpec(
-                key="average_fuel_consumption",
-                path=("energyReport", "total", "avgFuelConsum"),
-                translation_key="average_fuel_consumption",
-                source="energy_report",
-                native_unit_of_measurement="L/100km",
-                state_class="measurement",
-            ),
-        ),
+        sensors=_COMMON_SENSORS,
     ),
 )
 

--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -355,8 +355,44 @@ DEVICES: tuple[VehicleSpec, ...] = (
 )
 
 
-def vehicle_spec_for(vehicle: Vehicle) -> VehicleSpec | None:
-    return next((spec for spec in DEVICES if spec.matches(vehicle)), None)
+# Power types with no combustion engine, so the fuel sensors never apply.
+_ELECTRIC_ONLY_POWER_TYPES = frozenset({"BEV", "EV", "PURE_ELECTRIC"})
+_FUEL_SENSOR_KEYS = frozenset(
+    {"fuel_wltc_remaining_mileage", "fuel_remaining", "average_fuel_consumption"}
+)
+
+
+def _generic_spec(vehicle: Vehicle) -> VehicleSpec:
+    """Build a best-effort spec for a model without an explicit entry.
+
+    Every sensor reads the same dynamic-infos sections that all models return,
+    so a field the vehicle does not report simply stays unknown. The controls
+    are enabled as well, because each control entity already reports itself
+    unavailable while its backing field is missing (departure plan list, sentry
+    mode status, hvac section) and a command the vehicle rejects surfaces as an
+    error instead of acting. That way a model nobody has declared yet still
+    exposes the data and controls it actually has, rather than nothing.
+    """
+    profile = vehicle.profile
+    sensors = _COMMON_SENSORS
+    if (profile.power_type or "").upper() in _ELECTRIC_ONLY_POWER_TYPES:
+        sensors = tuple(sensor for sensor in sensors if sensor.key not in _FUEL_SENSOR_KEYS)
+    return VehicleSpec(
+        key="generic",
+        enterprise_code=profile.enterprise_code or "",
+        project_code=profile.project_code or "",
+        sensors=sensors,
+        supports_now_departure_plan=True,
+        supports_sentry_mode=True,
+        supports_air_conditioner=True,
+        supports_location=True,
+    )
+
+
+def vehicle_spec_for(vehicle: Vehicle) -> VehicleSpec:
+    """Return the declared spec for this vehicle, or a generic best-effort one."""
+    declared = next((spec for spec in DEVICES if spec.matches(vehicle)), None)
+    return declared if declared is not None else _generic_spec(vehicle)
 
 
 def dynamic_sections(spec: VehicleSpec) -> dict[str, int]:


### PR DESCRIPTION
> 本 PR 合并了原 #9（共享传感器表），#9 已关闭。两个 commit：先去重，再加兜底。

## 问题
1. `SERES-X1`（问界 M5）只声明了 12 个传感器，而这 12 个跟 `SERES-F3`（M8）的前 12 个**逐字相同**，另外 11 个完全缺失（车内温度、空调设定温度、四轮胎压、综合剩余里程、充电状态、驻车状态、两个时间戳）→ M5 几乎看不到数据。
2. 更普遍的问题：**没有显式 spec 的车型什么实体都没有**（`vehicle_spec_for()` 返回 `None`），每来一个新车型都得先写代码。

## 修改
**① 抽出 `_COMMON_SENSORS` 公共表**，两个车型共同引用。这些字段都来自同一批 `dynamic-infos` section（`charge`/`fuel`/`vehicleStatus`/`hvac`/`tire`），并非车型特有。以后新增传感器所有车型一起受益。

**② 匹配不到 spec 时回退到通用 spec**：
- **传感器**：用公共表。车辆不上报的字段自然是 unknown（sticky 传感器保留上次真值）。只读，无风险。
- **控制：也默认开启**。依据是每个控制实体**本来就按数据自门控**——备车要 `departurePlan.departurePlanList`、哨兵要 `vehicleStatus.sentryModeStatus`、空调要 `hvac` section，缺了就报 unavailable；而车端拒绝的指令以错误形式暴露、不会真的动作（"状态未变" 的 302 已按成功处理）。所以默认开启不会给出假开关、也不会静默误触发，而未声明的车型不再白白失去它实际拥有的功能。
- **纯电车型**（`powerType` 为 BEV/EV）自动去掉 3 个燃油传感器，避免永远 unknown。

已声明车型**行为不变**：`SERES-F3`/`SERES-X1` 仍优先匹配自己的 spec、保留各自能力开关（X1 依然没有备车）。

净减少 73 行。

## 验证
| 场景 | 结果 |
|---|---|
| M8 (`SERES-F3`) | 原 spec，23 传感器，备车 ✅ |
| M5 (`SERES-X1`) | 原 spec，23 传感器，**备车仍关闭** ✅ |
| 未知增程车型 | 通用 spec，23 传感器，能力全开 |
| 未知纯电车型 | 20 传感器（燃油类已排除） |
| 其他品牌未知车型 | 通用 spec |

真机侧：M8 全新登录后 29 个实体全部取到值（电量 42%、四轮胎压 2.6bar、车内 29.4℃、空调 23.0℃、驻车、里程 9719.4km）。

## 需要你判断的两点
- **胎压**：`tire` section 是本 PR 才为 `SERES-X1` 新增的，我只有 M8 实车、**没有 M5 可验证**。若 M5 不上报，这 4 个传感器会是 unknown（无害）。
- **控制默认开**：依赖实体自门控 + 车端校验。我**没验证过其他车型下发不支持指令的返回**（M8 上是 302 被拒、无副作用）。如你认为该更保守，把兜底 spec 的 `supports_*` 设为 `False` 即可，传感器部分不受影响。