### PR TITLE
feat: expose vehicle move status

### DIFF
--- a/cards/aito-card.js
+++ b/cards/aito-card.js
@@ -10,6 +10,7 @@
 const PREP_KEY = 'now_departure_plan';
 const SENTRY_KEY = 'sentry_mode';
 const CLIMATE_KEY = 'air_conditioner';
+const MOVE_STATUS_KEY = 'vehicle_move_status';
 const PENDING_TIMEOUT_MS = 30000;
 // 第一个控制键：有备车能力(M8)就是备车开关，没有(M5)就退化为空调开关。
 // 车图由集成合成到 /local/aito/car.png。带版本号 bust 浏览器强缓存——
@@ -228,7 +229,7 @@ class AitoCard extends HTMLElement {
           <div class="cell" data-entity="sum_remaining_mileage"><div class="cell-val" id="sum-range"></div><div class="cell-label">综合续航</div></div>
           <div class="cell" data-entity="inside_temperature"><div class="cell-val" id="inside"></div><div class="cell-label">车内</div></div>
           <div class="cell" data-entity="air_conditioner"><div class="cell-val" id="ac"></div><div class="cell-label">空调</div></div>
-          <div class="cell" data-entity="parking_status"><div class="cell-val" id="status"></div><div class="cell-label">状态</div></div>
+          <div class="cell" data-entity="vehicle_move_status"><div class="cell-val" id="status"></div><div class="cell-label">状态</div></div>
         </div>
 
         <div class="grid">
@@ -416,12 +417,15 @@ class AitoCard extends HTMLElement {
     this._$('inside').textContent = `🌡️ ${num(this._s('inside_temperature'))}°`;
     this._$('ac').textContent = `❄️ ${num(this._s('air_conditioner_target_temperature'))}°`;
 
-    const parkingState = this._s('parking_status');
-    const parked = parkingState === '停泊';
+    const moveStatus = this._s(MOVE_STATUS_KEY);
+    const moveStatusTranslationKey = `component.aito.entity.sensor.${MOVE_STATUS_KEY}.state.${moveStatus}`;
+    const localizedMoveStatus = this._hass?.localize?.(moveStatusTranslationKey);
+    const displayMoveStatus =
+      localizedMoveStatus === moveStatusTranslationKey ? moveStatus : localizedMoveStatus || moveStatus;
     this._$('status').textContent =
-      parkingState === '--' || parkingState === 'unknown' || parkingState === 'unavailable'
+      moveStatus === '--' || moveStatus === 'unknown' || moveStatus === 'unavailable'
         ? '🚘 --'
-        : `${parked ? '🅿️' : '🚗'} ${parkingState}`;
+        : `${moveStatus === '0' ? '🅿️' : '🚗'} ${displayMoveStatus}`;
 
     for (const [id, tk] of [
       ['tire-fl', 'tire_pressure_left_front'],

--- a/custom_components/aito/devices.py
+++ b/custom_components/aito/devices.py
@@ -160,14 +160,13 @@ def _epoch_millis(value: Any) -> datetime | None:
     return None
 
 
-def _parking_text(value: Any) -> str | None:
-    """Report the electric park brake as the parked or driving state."""
-    if value is None:
-        return None
+def _vehicle_move_status(value: Any) -> int | None:
+    """Keep valid official vehicleMoveStatus enum values."""
     try:
-        return "停泊" if int(value) == 2 else "行驶"
+        status = int(value)
     except (TypeError, ValueError):
         return None
+    return status if status in {0, 1, 2} else None
 
 
 DEVICES: tuple[VehicleSpec, ...] = (
@@ -326,10 +325,10 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 value_getter=_charge_display_status_text,
             ),
             SensorSpec(
-                key="parking_status",
-                path=("vehicleStatus", "epbSts"),
-                translation_key="parking_status",
-                converter=_parking_text,
+                key="vehicle_move_status",
+                path=("vehicleStatus", "vehicleMoveStatus"),
+                translation_key="vehicle_move_status",
+                converter=_vehicle_move_status,
             ),
             SensorSpec(
                 key="inside_temperature",
@@ -545,10 +544,10 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 value_getter=_charge_display_status_text,
             ),
             SensorSpec(
-                key="parking_status",
-                path=("vehicleStatus", "epbSts"),
-                translation_key="parking_status",
-                converter=_parking_text,
+                key="vehicle_move_status",
+                path=("vehicleStatus", "vehicleMoveStatus"),
+                translation_key="vehicle_move_status",
+                converter=_vehicle_move_status,
             ),
             SensorSpec(
                 key="inside_temperature",
@@ -766,10 +765,10 @@ DEVICES: tuple[VehicleSpec, ...] = (
                 value_getter=_charge_display_status_text,
             ),
             SensorSpec(
-                key="parking_status",
-                path=("vehicleStatus", "epbSts"),
-                translation_key="parking_status",
-                converter=_parking_text,
+                key="vehicle_move_status",
+                path=("vehicleStatus", "vehicleMoveStatus"),
+                translation_key="vehicle_move_status",
+                converter=_vehicle_move_status,
             ),
             SensorSpec(
                 key="inside_temperature",

--- a/custom_components/aito/strings.json
+++ b/custom_components/aito/strings.json
@@ -83,8 +83,13 @@
       "charge_status": {
         "name": "Charging status"
       },
-      "parking_status": {
-        "name": "Parking status"
+      "vehicle_move_status": {
+        "name": "Vehicle move status",
+        "state": {
+          "0": "Parked",
+          "1": "Driving",
+          "2": "Preparing"
+        }
       },
       "inside_temperature": {
         "name": "Cabin temperature"

--- a/custom_components/aito/translations/zh-Hans.json
+++ b/custom_components/aito/translations/zh-Hans.json
@@ -83,8 +83,13 @@
       "charge_status": {
         "name": "充电状态"
       },
-      "parking_status": {
-        "name": "驻车状态"
+      "vehicle_move_status": {
+        "name": "车辆移动状态",
+        "state": {
+          "0": "停泊中",
+          "1": "行驶中",
+          "2": "准备中"
+        }
       },
       "inside_temperature": {
         "name": "车内温度"


### PR DESCRIPTION
Replaces parking-brake status with the official vehicle movement state and updates the Lovelace card.