### PR TITLE
feat: add Wenjie M5 U variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 | 品牌 | 官网当前车型/系列 | 本集成当前接入状态 |
 | --- | --- | --- |
-| 问界 | M5、M6、M7、M8、M9 | **已接入**：M5（`SERES-X1`、`SERES-X1EV-24-C`）、M6（`AITO-A15`）、M7（`SERES-F1-24-H`、`SERES-F1-24-U`）、M8（`SERES-F3`） |
+| 问界 | M5、M6、M7、M8、M9 | **已接入**：M5（`SERES-X1`、`SERES-X1-24-U`、`SERES-X1EV-24-C`）、M6（`AITO-A15`）、M7（`SERES-F1-24-H`、`SERES-F1-24-U`）、M8（`SERES-F3`） |
 | 享界 | S9、S9T、G9 | 未接入 |
 | 智界 | S7、R7、V9 | **已接入**：R7（`EHY-REEV-2025MY`） |
 | 尚界 | H5、Z7、Z7T | **已接入**：H5（`saic_h5`） |

--- a/custom_components/huawei_auto_cloud/omp/enterprises.py
+++ b/custom_components/huawei_auto_cloud/omp/enterprises.py
@@ -130,7 +130,7 @@ _SERES_DISCOVERY = DiscoveryPlan(DiscoverySource.IVCS_VCAM, DiscoverySource.OMP_
 
 SERES_BINDING = _binding(
     "seres_ivcs", "SERES", "", "https://apig.fgaiservice.com",
-    frozenset({"seres_f3", "seres_aito_a15", "seres_x1", "seres_x1ev_24_c", "seres_f1_24_h", "seres_f1_24_u"}), _SERES_DISCOVERY, "2026-08-seres",
+    frozenset({"seres_f3", "seres_aito_a15", "seres_x1", "seres_x1_24_u", "seres_x1ev_24_c", "seres_f1_24_h", "seres_f1_24_u"}), _SERES_DISCOVERY, "2026-08-seres",
     enabled_operations=_NORMAL_IVCS_OPERATIONS | {VehicleOperation.ENERGY_REPORT, VehicleOperation.LOCATION, VehicleOperation.FIRMWARE},
 )
 CHERY_BINDING = _binding(

--- a/custom_components/huawei_auto_cloud/specs.py
+++ b/custom_components/huawei_auto_cloud/specs.py
@@ -334,6 +334,17 @@ SPECS: tuple[VehicleSpec, ...] = (
         supports_location=True,
     ),
     VehicleSpec(
+        key="seres_x1_24_u",
+        enterprise_code="SERES",
+        project_code="SERES-X1-24-U",
+        sensors=SERES_COMMON_SENSORS,
+        controls=frozenset({
+            VehicleControl.AIR_CONDITIONER,
+            VehicleControl.SENTRY_MODE,
+        }),
+        supports_location=True,
+    ),
+    VehicleSpec(
         key="seres_x1ev_24_c",
         enterprise_code="SERES",
         project_code="SERES-X1EV-24-C",


### PR DESCRIPTION
## 概述
- 新增问界 M5 SERES-X1-24-U 项目变体的车型识别与 SERES IVCS binding 准入
- 复用已接入 M5 的动态状态、普通空调和哨兵能力
- 更新 README 的 M5 支持型号

## 验证
- python -m compileall -q custom_components/huawei_auto_cloud
- git diff --check

说明：现有严格车型清单测试未随本次提交更新，按当前维护策略测试文件不纳入提交范围。